### PR TITLE
Fix a concurrent modification exception

### DIFF
--- a/laravelechoandroid/src/main/java/net/mrbin99/laravelechoandroid/connector/SocketIOConnector.java
+++ b/laravelechoandroid/src/main/java/net/mrbin99/laravelechoandroid/connector/SocketIOConnector.java
@@ -16,6 +16,7 @@ import net.mrbin99.laravelechoandroid.channel.SocketIOPrivateChannel;
 
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -129,15 +130,20 @@ public class SocketIOConnector extends AbstractConnector {
         String privateChannel = "private-" + channel;
         String presenceChannel = "presence-" + channel;
 
-        for (String subscribed : channels.keySet()) {
+        Iterator<Map.Entry<String, SocketIOChannel>> iterator = channels.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, SocketIOChannel> entry = iterator.next();
+            SocketIOChannel socketIOChannel = entry.getValue();
+            String subscribed = entry.getKey();
+
             if (subscribed.equals(channel) || subscribed.equals(privateChannel) || subscribed.equals(presenceChannel)) {
                 try {
-                    channels.get(subscribed).unsubscribe(null);
+                    socketIOChannel.unsubscribe(null);
                 } catch (EchoException e) {
                     e.printStackTrace();
                 }
 
-                channels.remove(subscribed);
+                iterator.remove();
             }
         }
     }


### PR DESCRIPTION
This PR fixes a concurrent modification exception that happens when leaving a channel.

The stack trace of this error:
```
 java.util.ConcurrentModificationException
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1441)
        at java.util.HashMap$KeyIterator.next(HashMap.java:1465)
        at net.mrbin99.laravelechoandroid.connector.SocketIOConnector.leave(SocketIOConnector.java:132)
        at net.mrbin99.laravelechoandroid.Echo.leave(Echo.java:116)
```

This error was caused by iterating over the map's key set while also removing from the map's backing data store.

The fix is to use an iterator on the map entry set and the iterator's `remove` method to update the map's backing data store from within the loop.