### PR TITLE
Prevent a crash when checking if a socket is connected before establishing the first connection

### DIFF
--- a/laravelechoandroid/src/main/java/net/mrbin99/laravelechoandroid/connector/SocketIOConnector.java
+++ b/laravelechoandroid/src/main/java/net/mrbin99/laravelechoandroid/connector/SocketIOConnector.java
@@ -144,7 +144,7 @@ public class SocketIOConnector extends AbstractConnector {
 
     @Override
     public boolean isConnected() {
-        return socket.connected();
+        return socket != null && socket.connected();
     }
 
     @Override


### PR DESCRIPTION
Since the `socket` object is initialized in the `connect` method this PR fixes a crash by adding a null check in case `isConnected` is called before the first connection is established.